### PR TITLE
fix uarea initialization related to NYGLOB cpp

### DIFF
--- a/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
+++ b/cicecore/cicedynB/dynamics/ice_dyn_shared.F90
@@ -11,6 +11,7 @@
       module ice_dyn_shared
 
       use ice_kinds_mod
+      use ice_communicate, only: my_task, master_task
       use ice_constants, only: c0, c1, p01, p001
       use ice_blocks, only: nx_block, ny_block
       use ice_domain_size, only: max_blocks
@@ -101,7 +102,6 @@
       subroutine init_evp (dt)
 
       use ice_blocks, only: nx_block, ny_block
-      use ice_communicate, only: my_task, master_task
       use ice_constants, only: c0, c2, omega
       use ice_domain, only: nblocks
       use ice_domain_size, only: max_blocks
@@ -187,7 +187,6 @@
 
       subroutine set_evp_parameters (dt)
 
-      use ice_communicate, only: my_task, master_task
       use ice_constants, only: p25, c1, c2, c4, p5
       use ice_domain, only: distrb_info
       use ice_global_reductions, only: global_minval, global_maxval

--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -191,9 +191,10 @@
       abort_flag = 0
 
       call icepack_query_parameters(puny_out=puny)
-      call icepack_warnings_flush(nu_diag)
-      if (icepack_warnings_aborted()) call abort_ice(error_message=subname//'Icepack Abort0', &
-         file=__FILE__, line=__LINE__)
+! nu_diag not yet defined
+!      call icepack_warnings_flush(nu_diag)
+!      if (icepack_warnings_aborted()) call abort_ice(error_message=subname//'Icepack Abort0', &
+!         file=__FILE__, line=__LINE__)
 
       days_per_year = 365    ! number of days in a year
       use_leap_years= .false.! if true, use leap years (Feb 29)
@@ -878,7 +879,13 @@
          write(nu_diag,1020) ' kitd                      = ', kitd
          write(nu_diag,1020) ' kcatbound                 = ', &
                                kcatbound
-         write(nu_diag,1020) ' kdyn                      = ', kdyn
+         if (kdyn == 1) then
+           write(nu_diag,1020) ' kdyn                      = evp ', kdyn
+         elseif (kdyn == 2) then
+           write(nu_diag,1020) ' kdyn                      = eap ', kdyn
+         else
+           write(nu_diag,1020) ' kdyn                      = ', kdyn
+         endif
          write(nu_diag,1020) ' ndtd                      = ', ndtd
          write(nu_diag,1020) ' ndte                      = ', ndte
          write(nu_diag,1010) ' revised_evp               = ', &

--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1491,26 +1491,23 @@
       endif
 
       if (my_task == master_task) then
-      do j = 1, ny_global
-      do i = 1, nx_global
-         work_g(i,j) = work_g(i,j) * cm_to_m                ! HTE
-      enddo
-      enddo
-      do j = 1, ny_global-1
+         do j = 1, ny_global
+         do i = 1, nx_global
+            work_g(i,j) = work_g(i,j) * cm_to_m                ! HTE
+         enddo
+         enddo
+         do j = 1, ny_global-1
          do i = 1, nx_global
             work_g2(i,j) = p5*(work_g(i,j) + work_g(i,j+1)) ! dyu
          enddo
-      enddo
-      ! extrapolate to obtain dyu along j=ny_global
-      ! for CESM: use NYGLOB to prevent a compile time out of bounds 
-      ! error when ny_global=1 as in the se dycore; this code is not 
-      ! exersized in prescribed mode.
-#if (NYGLOB>2)
-      do i = 1, nx_global
-         work_g2(i,ny_global) = c2*work_g(i,ny_global-1) &
-                                 - work_g(i,ny_global-2) ! dyu
-      enddo
-#endif
+         enddo
+         ! extrapolate to obtain dyu along j=ny_global
+         if (ny_global > 1) then
+            do i = 1, nx_global
+               work_g2(i,ny_global) = c2*work_g(i,ny_global-1) &
+                                       - work_g(i,ny_global-2) ! dyu
+            enddo
+         endif
       endif
       call scatter_global(HTE, work_g, master_task, distrb_info, &
                           field_loc_Eface, field_type_scalar)


### PR DESCRIPTION
Fixes the uarea calculation at ny_global which was implemented with a cpp depending on NYGLOB (which no longer exists).  This is line 1508 in ice_grid.F90.  The other changes are just indentation in that same area and a couple other minor fixes.

This fixes some of the problems, see

https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks

hash 465cd86aea.  But pgi is still not behaving well and I will look into that next.