### PR TITLE
mods for nag compiler failure

### DIFF
--- a/cicecore/cicedynB/infrastructure/ice_grid.F90
+++ b/cicecore/cicedynB/infrastructure/ice_grid.F90
@@ -1232,8 +1232,8 @@
 
             ! land in the upper left and lower right corners,
             ! otherwise open boundaries
-            imid = aint(real(nx_global)/c2,kind=int_kind)
-            jmid = aint(real(ny_global)/c2,kind=int_kind)
+            imid = nint(aint(real(nx_global)/c2))
+            jmid = nint(aint(real(ny_global)/c2))
 
             do j = 3,ny_global-2
             do i = 3,nx_global-2


### PR DESCRIPTION
nag compiler complains on AllocDyn branch but not on master, for reasons I don't understand,

error: conversion to non-scalar type requested
             imid = aint(real(nx_global)/c2,kind=int_kind)

This was refactored.  The AllocDyn branch was tested on hobart nag against the current master and is bit-for-bit and produces the same test results.